### PR TITLE
use __FILE_NAME__ instead of __FILE__ for lwip assertion

### DIFF
--- a/src/lwipopts.h
+++ b/src/lwipopts.h
@@ -71,7 +71,8 @@
 #define SYS_ARCH_UNPROTECT(lev)    (void)0
 
 #define LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS 1
-
+#define LWIP_PLATFORM_ASSERT(x) do {fprintf(stderr, "Assertion \"%s\" failed at line %d in %s\n", \
+                                     x, __LINE__, __FILE_NAME__); abort();} while(0)
 #define lwip_htons(x)                  htobe16(x)
 #define lwip_htonl(x)                  htobe32(x)
 #define lwip_strnstr(buffer, token, n) strnstr(buffer, token, n)


### PR DESCRIPTION
`LWIP_PLATFORM_ASSERT` defined at lwip/include/arch.h would use `__FILE__` macro to print assert messages with file paths. But those paths would be absolute paths carrying informations about the build host.

On one hand, this might expose sensitive data about the building host, considering most would build the package under the home, especially when one is redistributing nsproxy, like onto Github releases or into a distro library.

On the other hand, this adds unneeded information and lowers the signal-to-noise ratio when one wants to trace the issue, especially when the source is built in a folder with a very long path.

An example of the exposed path could be obtained by simply downloading the latest Github release from https://github.com/nlzy/nsproxy/releases/download/v0.2.0/nsproxy_x86_64-linux-musl and running a simple grep command like this:
```
grep -a 'lwip/ipv4/icmp.c' ~/Downloads/nsproxy_x86_64-linux-musl
```

Although only lwip sources are affected, only overload the assertion call in our header locally, to avoid impact to lwip sources and increased burnden to merge upstream changes.